### PR TITLE
Support Phlex DSL on scenarios

### DIFF
--- a/app/views/lookbook/previews/preview.html.erb
+++ b/app/views/lookbook/previews/preview.html.erb
@@ -1,9 +1,5 @@
 <% if @render_args[:component] %>
-  <% if defined?(Phlex::SGML) && @render_args[:component].is_a?(Phlex::SGML) %>
-    <%= raw(@render_args[:component].call(view_context: self, &@render_args[:block])) %>
-  <% else %>
-    <%= render(@render_args[:component], @render_args[:args], &@render_args[:block]) %>
-  <% end %>
+  <%= render(@render_args[:component], @render_args[:args], &@render_args[:block]) %>
 <% else %>
   <%= render(@render_args[:template], **@render_args[:locals], &@render_args[:block]) %>
 <% end %>

--- a/lib/lookbook/phlex_preview.rb
+++ b/lib/lookbook/phlex_preview.rb
@@ -1,0 +1,9 @@
+module Lookbook
+  class PhlexPreview < Preview
+    def render(component, &block)
+      super do
+        component.instance_exec component, &block
+      end
+    end
+  end
+end

--- a/spec/dummy/app/views/phlex/card_example.rb
+++ b/spec/dummy/app/views/phlex/card_example.rb
@@ -1,0 +1,11 @@
+module Views::Phlex
+  class CardExample < Phlex::HTML
+    def template(&content)
+      div class: "card", &content
+    end
+
+    def footer(&content)
+      div class: "card-footer", &content
+    end
+  end
+end

--- a/spec/dummy/test/components/previews/phlex_dsl_example_preview.rb
+++ b/spec/dummy/test/components/previews/phlex_dsl_example_preview.rb
@@ -1,0 +1,18 @@
+class PhlexDslExamplePreview < Lookbook::PhlexPreview
+  def default
+    render Views::Phlex::CardExample.new do |card|
+      h1 { "My card" }
+
+      div class: "card-body" do
+        render Views::Phlex::ListExample.new do |list|
+          list.item { "Hello" }
+          list.item { "World" }
+        end
+      end
+
+      card.footer do
+        span { "Hey ya!" }
+      end
+    end
+  end
+end

--- a/spec/requests/previews_spec.rb
+++ b/spec/requests/previews_spec.rb
@@ -45,6 +45,17 @@ RSpec.describe "previews", type: :request do
         expect(html.has_css?("li", text: "World")).to be true
       end
     end
+
+    context "Phlex DSL" do
+      it "supports Phlex DSL" do
+        get lookbook_preview_path("phlex_dsl_example/default")
+
+        expect(html.has_css?(".card > h1", text: "My card")).to be true
+        expect(html.has_css?(".card > .card-body > ul > li", text: "Hello")).to be true
+        expect(html.has_css?(".card > .card-body > ul > li", text: "World")).to be true
+        expect(html.has_css?(".card > .card-footer > span", text: "Hey ya!")).to be true
+      end
+    end
   end
 
   context "View partials" do


### PR DESCRIPTION
Fixes: https://github.com/ViewComponent/lookbook/issues/584

I'm not sure if this is the best solution but it's working 😅

Instead evaluating the block on Lookbook::Preview context, it is evaluating on component context, so it can render other components and use Phlex DSL.