### PR TITLE
fix dynamic param value contains double-quotes make alpine x-data has…

### DIFF
--- a/app/components/lookbook/base_component.rb
+++ b/app/components/lookbook/base_component.rb
@@ -33,11 +33,7 @@ module Lookbook
     end
 
     def alpine_encode(data)
-      if data.is_a? String
-        "'#{json_escape data}'"
-      else
-        json_escape data.to_json.tr("\"", "'")
-      end
+      data.to_json
     end
 
     def prepare_alpine_data(x_data = nil)

--- a/app/components/lookbook/params/field/component.rb
+++ b/app/components/lookbook/params/field/component.rb
@@ -14,10 +14,10 @@ module Lookbook
         styles, html = StylesExtractor.call(render_input)
         Editor::Component.add_styles(param.input, styles)
 
-        escaped_value = json_escape(param.value.to_s).gsub("\n", '\n')
+        data = { name: param.name, value: param.value }.to_json
         wrapper_attrs = {
           data: {"param-input": param.input},
-          "x-data": "paramsInputComponent({name: \"#{param.name}\", value: \"#{escaped_value}\"})"
+          "x-data": "paramsInputComponent(#{data})"
         }
         @rendered_input = tag.div(**wrapper_attrs) { html.html_safe }
       end


### PR DESCRIPTION
we can simply pass string to x-data with `.to_json`. The old code broken when I type double-quotes in dynamic param text field.