### PR TITLE
Use the Lucide sprite instead of injecting individual SVGs onto the page

### DIFF
--- a/app/components/lookbook/icon/component.html.erb
+++ b/app/components/lookbook/icon/component.html.erb
@@ -1,3 +1,5 @@
 <%= render_component_tag :i, style: "height: #{size_rems}; width: #{size_rems}; #{@html_attrs[:style]}", class: "icon-stroke-#{stroke}" do %>
-  <%= svg %>
+  <svg>
+    <use href="/lookbook-assets/img/lucide-sprite.svg#<%= @icon_name %>"></use>
+  </svg>
 <% end %>

--- a/app/components/lookbook/icon/component.rb
+++ b/app/components/lookbook/icon/component.rb
@@ -14,21 +14,5 @@ module Lookbook
     def size_rems
       "#{@size * 0.25}rem"
     end
-
-    def svg
-      ICON_CACHE[@icon_name] ||= read_svg
-    end
-
-    def read_svg
-      File.read(svg_path).html_safe
-    rescue
-      if Rails.env.development? || Rails.env.test?
-        raise "`#{@icon_name}` is not a valid icon name"
-      end
-    end
-
-    def svg_path
-      Lookbook::Engine.root.join("assets/icons/#{@icon_name}.svg")
-    end
   end
 end


### PR DESCRIPTION
Hey there @allmarkedup 👋 it's me again 😄

A co-worker noticed the Primer Lookbook instance loading quite slowly and discovered there are ~600 SVGs on many of our pages. It looks like Lookbook copies the SVG source onto the page for every icon, which the co-worker surmised is leading to long render times on the server. I noticed Lookbook comes with a sprite that includes all the Lucide icons in the img/ directory, so I thought maybe we could just use that instead?

I tried replacing the SVG source with a `<use>` element, and it seems to work nicely. Page render times seem to be a little speedier too, although I won't know how much impact it has on Primer's Lookbook instance until we deploy to prod.

Let me know what you think 😄 