### PR TITLE
Use dig in layouts guide ERB

### DIFF
--- a/docs/src/_extend/other/data.md
+++ b/docs/src/_extend/other/data.md
@@ -56,7 +56,7 @@ title: Global Data Store
   <!-- app/views/layouts/preview.html.erb -->
   ...
   <div><%%= yield %></div>
-  <p>Built by <%%= params[:lookbook][:data][:company_name] %></p>
+  <p>Built by <%%= params.dig(:lookbook, :data, :company_name) %></p>
   ...
   ```
 

--- a/docs/src/_guide/previews/display.md
+++ b/docs/src/_guide/previews/display.md
@@ -29,17 +29,17 @@ title: Display Options
     end
     ```
 
-    Display param values can then be accessed via the `params` hash in your preview layout using `params[:lookbook][:display][<key>]`:
+    Display param values can then be accessed via the `params` hash in your preview layout using `params.dig(:lookbook, :display, <key>)`:
 
     ```html
     <!DOCTYPE html>
-    <html style="background-color: <%%= params[:lookbook][:display][:bg_color] %>">
+    <html style="background-color: <%%= params.dig(:lookbook, :display, :bg_color) %>">
       <head>
         <title>Preview Layout</title>
       </head>
       <body>
-        <div style="max-width: <%%= params[:lookbook][:display][:max_width] || '100%' %>">
-          <%% if params[:lookbook][:display][:wrapper] == true %>
+        <div style="max-width: <%%= params.dig(:lookbook, :display, :max_width) || '100%' %>">
+          <%% if params.dig(:lookbook, :display, :wrapper) == true %>
           <div class="wrapper"><%%= yield %></div>
           <%% else %> <%%= yield %> <%% end %>
         </div>
@@ -136,7 +136,7 @@ title: Display Options
     <!DOCTYPE html>
     <html>
       <head>
-        <link href="<%%= params[:lookbook][:display][:theme] %>.css" rel="stylesheet" />
+        <link href="<%%= params.dig(:lookbook, :display, :theme) %>.css" rel="stylesheet" />
       </head>
       <body>
         <%%= yield %>

--- a/docs/src/_guide/previews/layouts.md
+++ b/docs/src/_guide/previews/layouts.md
@@ -56,7 +56,7 @@ title: Preview Layouts
     ```erb
     <!-- app/views/layouts/component_preview.html.erb -->
     <!DOCTYPE html>
-    <html style="background-color: <%%= params[:lookbook][:display][:bg_color] || "white" %>">
+    <html style="background-color: <%%= params.dig(:lookbook, :display, :bg_color) || "white" %>">
     <head>
       <title>Component Preview</title>
       <meta name="viewport" content="width=device-width,initial-scale=1">
@@ -67,7 +67,7 @@ title: Preview Layouts
       <div style="
         margin-left: auto;
         margin-right: auto;
-        max-width: <%%= params[:lookbook][:display][:max_width] || "100%" %>
+        max-width: <%%= params.dig(:lookbook, :display, :max_width) || "100%" %>
       ">
         <%%= yield %> <!-- rendered preview will be injected here -->
       </div>


### PR DESCRIPTION
If one uses the suggested layout for the ViewComponent default layout, navigating to `localhost:3000/rails/view_components` will throw an error due to the deeply nested nature of the Lookbook params hash. Using `dig` allows for safe access into the hashes without causing problems if any of the keys don't exist.

Hash#dig was introduced in Ruby 2.3, so will be available in all supported versions of Lookbook.

There's a few other instances of `params[:some][:deep][:key]` in the docs, but I thought this one may be a better target since it could cross the Lookbook boundary to ViewComponent.