### PR TITLE
Feature | `lazy_load_previews_and_pages` config option

### DIFF
--- a/config/app.yml
+++ b/config/app.yml
@@ -50,6 +50,7 @@ shared:
   component_paths: [app/views, app/components]
 
   reload_on_change: ~
+  lazy_load_previews_and_pages: false
   live_updates: false
   listen_paths: []
   listen_extensions: [rb, html.*]

--- a/docs/src/_data/config_options.yml
+++ b/docs/src/_data/config_options.yml
@@ -261,7 +261,16 @@ system:
     example: config.lookbook.reload_on_change = true
     description: |
       By default Lookbook uses the value of the `cache_classes` and `reload_classes_only_on_change` Rails config options to decide if
-      it should attempt to update the preview data after changes. If set the value of this config option will take precedence and be used instead.
+      it should attempt to update the preview data after changes. If set, the value of this config option will take precedence and be used instead.
+
+  - name: lazy_load_previews_and_pages
+    types: Boolean
+    default: "false"
+    example: config.lookbook.lazy_load_previews_and_pages = true
+    description: |
+      By default Lookbook loads all preview and page data on application initialization, and then on changes depending
+      on the value of `config.lookbook.reload_on_change`. If set to `true`, Lookbook will defer the initial loading of
+      preview and page data until it is first requested.
 
   - name: live_updates
     types: Boolean

--- a/lib/lookbook/reloaders.rb
+++ b/lib/lookbook/reloaders.rb
@@ -16,6 +16,8 @@ module Lookbook
         Rails.application.reloaders << reloader
         Rails.application.reloader.to_run { reloader.execute_if_updated }
       end
+
+      reloader
     end
 
     def execute


### PR DESCRIPTION
Hello, we're loving lookbook over at @buildkite.

Recently I've been doing some benchmarking of our application boot times and found that lookbook's eager loading of previews and pages in an `after_initialization` hook contributes ~250ms (~12%) to our boot time* in development, which is the only environment in which we have lookbook configured (for now at least). We have ~35 previews and ~5 pages at the time of writing, and I'm assuming that the time taken will gradually increase linearly as we add more.

I'm proposing a config option to defer the loading of the preview and page data to the first time it's needed, which from scouring the code seemed to be entity lookups when hitting the lookbook routes. This is especially useful when utilising the Rails console, runner, rake tasks etc. which don't need this data to be loaded.

I used [vernier](https://github.com/jhawthorn/vernier) to benchmark this with `bin/rails c`, you can go [here](https://vernier.prof/) and load the comparison outputs below:

- [output_before.json](https://github.com/user-attachments/files/17240992/output_before.json)
- [output_after.json](https://github.com/user-attachments/files/17240991/output_after.json)

I also then ensured that our previews and pages load as usual when first requested, and that if a preview or page changed before any were requested, all of them are loaded on the first change with the change reflected in the UI.

**Notes:**
- 'Boot time' here is from when `class Application` is defined to right after `Rails.application.initialize!` is called i.e. it excludes requiring Rails and other gems.
- This is a micro-optimisation for most apps, but could be a noticeable difference in larger applications, especially those with many more previews and pages.