### PR TITLE
Fix missing CSRF token in previews

### DIFF
--- a/app/views/layouts/lookbook/skeleton.html.erb
+++ b/app/views/layouts/lookbook/skeleton.html.erb
@@ -5,6 +5,8 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0">
 
+  <%= csrf_meta_tags %>
+
   <link href="<%= lookbook_asset_path("/css/lookbook.css") %>" rel="stylesheet">
   <link href="<%= lookbook_asset_path("/css/themes/#{@config.ui_theme}.css") %>" rel="stylesheet">
 


### PR DESCRIPTION
Adds missing CSRF meta tags so that  HTTP requests from previews don't throw `InvalidAuthenticityToken` exceptions, as reported in #632.