### PR TITLE
Adjust size of search filter close button

### DIFF
--- a/app/components/lookbook/filter/component.html.erb
+++ b/app/components/lookbook/filter/component.html.erb
@@ -11,7 +11,7 @@
       x-on:keydown.f.window="if (!($event.shiftKey || $event.metaKey || $event.ctrlKey || $event.altKey)) { focus(); $event.preventDefault(); $event.stopPropagation(); }"
       x-on:keydown.stop>
       <button class="text-lookbook-icon-button-stroke hover:text-lookbook-icon-button-stroke-hover focus:ring-0 focus:outline-none absolute top-1/2 right-3 -translate-y-1/2" x-on:click="clear" x-bind:class="{hidden: !active}">
-        <%= icon  :x, size: 3 %>
+        <%= icon  :x, size: 4 %>
       </button>
   </div>
 <% end %>


### PR DESCRIPTION
Resolves #613

|before|after|
|--|--|
|<img width="279" alt="スクリーンショット 2024-11-15 18 44 54" src="https://github.com/user-attachments/assets/d76886ef-52ef-4113-9443-575ee73141fe">|<img width="278" alt="スクリーンショット 2024-11-15 18 43 49" src="https://github.com/user-attachments/assets/26984e1a-f226-484a-9968-6771296a25f2">

