### PR TITLE
Add `html_escape` so that code cannot be ran based on URL params

### DIFF
--- a/app/components/lookbook/params/field/component.rb
+++ b/app/components/lookbook/params/field/component.rb
@@ -14,7 +14,7 @@ module Lookbook
         styles, html = StylesExtractor.call(render_input)
         Editor::Component.add_styles(param.input, styles)
 
-        escaped_value = json_escape(param.value.to_s).gsub("\n", '\n')
+        escaped_value = html_escape(json_escape(param.value.to_s).gsub("\n", '\n'))
         wrapper_attrs = {
           data: {"param-input": param.input},
           "x-data": "paramsInputComponent({name: \"#{param.name}\", value: \"#{escaped_value}\"})"


### PR DESCRIPTION
### Issue
This PR is part of https://github.com/lookbook-hq/lookbook/issues/669. The change attempts to ensure that the parameter value is properly escaped to prevent potential security vulnerabilities, such as XSS.

If the [`escaped_value`](https://github.com/lookbook-hq/lookbook/blob/main/app/components/lookbook/params/field/component.rb#L17-L21) contains the following value or similar then it could lead to XSS:

`"-alert(window.location.href)-"` - The `console.log` would be ran, as the quotes would evaluate to `NaN`, leaving the JavaScript within to be ran (i.e. `paramsInputComponent({name: 'text', value: ""-alert(window.location.href)-""})`.

[Example in Lookbook demo](https://demo.lookbook.build/lookbook/inspect/elements/button/playground?text=%22-alert(123)-%22)

### Solution

The easiest workaround seemed to be parsing the string and removing instances of quotes. This can be done utilizing `html_escape`, which removes special characters including quotes for more assurance. This shouldn't have any ill affects to how Lookbook processes params currently, as it'll only convert special characters to their HTML entity (e.g. `"` to `&quot;`), while retaining the actual value in the rendered UI.