### PR TITLE
Fix 667: "Cannot transliterate strings with ASCII encoding" during rails start

### DIFF
--- a/lib/lookbook/support/utils/utils.rb
+++ b/lib/lookbook/support/utils/utils.rb
@@ -12,7 +12,7 @@ module Lookbook
       end
 
       def name(str)
-        str.to_s.parameterize.tr("-", "_")
+        str.to_s.force_encoding("UTF-8").parameterize.tr("-", "_")
       end
 
       def symbolize_name(str)

--- a/spec/support/combustion.rb
+++ b/spec/support/combustion.rb
@@ -11,8 +11,23 @@ Combustion.initialize! :action_controller, :action_view do
   config.lookbook.project_name = "Lookbook Test App"
   config.lookbook.listen = false
   config.lookbook.using_view_component = true
-
   config.action_controller.default_url_options = {host: "localhost"}
 
   Lookbook.add_tag(:customtag)
+
+  # Regression case with exception:
+  #
+  #   "Cannot transliterate strings with ASCII-8BIT encoding (ArgumentError)"
+  #
+  # In order to simulate this bug we need to force ASCII for filenames (when we
+  # pass an ASCII string to Ruby's Dir[] method it returns filenames as ASCII,
+  # and in some environments, if the code is not explicitly forcing UTF-8 this
+  # will be the case for regular strings ion config files.
+  #
+  # Obs.: At this point here the Lookbook::Engine is already loaded and it
+  #   momoizes the page_paths, so it DOES NOT WORK by adding the
+  #   config.lookbook.page_paths here
+  Lookbook::Engine.page_paths.each do
+    _1.force_encoding(Encoding::ASCII_8BIT)
+  end
 end

--- a/spec/support/combustion.rb
+++ b/spec/support/combustion.rb
@@ -26,7 +26,7 @@ Combustion.initialize! :action_controller, :action_view do
   # will be the case for regular strings ion config files.
   #
   # Obs.: At this point here the Lookbook::Engine is already loaded and it
-  #   momoizes the page_paths, so it DOES NOT WORK by adding the
+  #   memoizes the page_paths, so it DOES NOT WORK by adding the
   #   config.lookbook.page_paths here
   Lookbook::Engine.page_paths.each do
     _1.force_encoding(Encoding::ASCII_8BIT)

--- a/spec/support/combustion.rb
+++ b/spec/support/combustion.rb
@@ -11,6 +11,7 @@ Combustion.initialize! :action_controller, :action_view do
   config.lookbook.project_name = "Lookbook Test App"
   config.lookbook.listen = false
   config.lookbook.using_view_component = true
+
   config.action_controller.default_url_options = {host: "localhost"}
 
   Lookbook.add_tag(:customtag)


### PR DESCRIPTION
In some environments, if the config files are not explicitly set to use UTF-8, the strings passed to `page_paths` goes encoded as ASCII and the engine pass this down to Ruby's Dir[] method which returns filenames in the same encoding:

```ruby
  Dir['/*'.force_encoding(Encoding::ASCII_8BIT)].map { [_1, _1.encoding] }
  => [
       ["/bin",  #<Encoding:ASCII-8BIT>],
       ["/boot", #<Encoding:ASCII-8BIT>],
       ["/dev",  #<Encoding:ASCII-8BIT>],
       ["/etc",  #<Encoding:ASCII-8BIT>],
       ...
```

```ruby
  Dir['/*'.force_encoding(Encoding::UTF_8)].map { [_1, _1.encoding] }
  => [
       ["/bin",  #<Encoding:UTF-8>],
       ["/boot", #<Encoding:UTF-8>],
       ["/dev",  #<Encoding:UTF-8>],
       ["/etc",  #<Encoding:UTF-8>],
       ...
```

At some point, we pass down these filenames through Rails' String#parameterize, which tries to transliterate it assuming it is a UTF string.

Obs.: instead of testing the utils method isolated, I chose to simulate the real regression by adding the config in the combustion.rb file, and I found another strange behavior there due to the fact that when that file is loaded the Lookbook::Engine already loaded and memoized the page_paths config with the standard "test/components/docs" path on it, it doesn't honor what is in that file for the page_paths config, so I ended up forcing the string that was already in the Engine.