### PR TITLE
support the correct params for phlex v2 call method

### DIFF
--- a/app/views/lookbook/previews/preview.html.erb
+++ b/app/views/lookbook/previews/preview.html.erb
@@ -1,6 +1,10 @@
 <% if @render_args[:component] %>
   <% if defined?(Phlex::SGML) && @render_args[:component].is_a?(Phlex::SGML) %>
-    <%= raw(@render_args[:component].call(view_context: self, &@render_args[:block])) %>
+    <% if @render_args[:component].method(:call).parameters.include?([:key, :context])%>
+      <%= raw(@render_args[:component].call(context: { rails_view_context: self }, &@render_args[:block])) %>
+    <% else %>
+      <%= raw(@render_args[:component].call(view_context: self, &@render_args[:block])) %>
+    <% end %>
   <% else %>
     <%= render(@render_args[:component], @render_args[:args], &@render_args[:block]) %>
   <% end %>


### PR DESCRIPTION
I'm not sure if this is exactly the best approach, and we should probably have appraisal run against phlex v1 & v2 if we want to support both, but this works.

Ideally, I wanted to check against `Phlex::VERSION`, but it seems that isn't autoloaded, so we'd have to put a
```ruby
require "phlex/version" if defined?(Phlex)
```
somewhere.