### PR TITLE
Fix height style for notes panel in Lookbook inspector

### DIFF
--- a/app/views/lookbook/inspector/panels/_notes.html.erb
+++ b/app/views/lookbook/inspector/panels/_notes.html.erb
@@ -11,7 +11,7 @@
     <% end %>
   </div>
 <% else %>
-  <div class="p-4 w-full h-max bg-lookbook-prose-bg">
+  <div class="p-4 w-full min-h-full h-max bg-lookbook-prose-bg">
     <%= lookbook_render :prose do %>
       <%== items.any? ? items.first.notes : "<em class='opacity-50'>No notes provided.</em>" %>
     <% end %>

--- a/app/views/lookbook/inspector/panels/_notes.html.erb
+++ b/app/views/lookbook/inspector/panels/_notes.html.erb
@@ -11,7 +11,7 @@
     <% end %>
   </div>
 <% else %>
-  <div class="p-4 w-full h-full bg-lookbook-prose-bg">
+  <div class="p-4 w-full h-max bg-lookbook-prose-bg">
     <%= lookbook_render :prose do %>
       <%== items.any? ? items.first.notes : "<em class='opacity-50'>No notes provided.</em>" %>
     <% end %>


### PR DESCRIPTION
Just a silly styling fix that was bothering me xD

Before:
The container was set to a fixed size, so when the notes had more than a few lines, they were overflowing, messing up the spacing and losing the background
![image](https://github.com/user-attachments/assets/196fea11-1f03-4215-a9b3-3670dcb2ec49)

After:
The container height is now set to fit the content, so spacing and background stay intact
![image](https://github.com/user-attachments/assets/c1133d81-6516-471a-bf59-774a50eff2d7)
