### PR TITLE
Fix preview parsing race condition with `lazy_load_previews_and_pages`

### DIFF
--- a/lib/lookbook/preview_parser.rb
+++ b/lib/lookbook/preview_parser.rb
@@ -6,15 +6,14 @@ module Lookbook
       @paths = paths
       @after_parse_callbacks = []
       @after_parse_once_callbacks = []
-      @parsing = false
+      @parsing = Mutex.new
 
       define_tags(tags)
       YARD::Parser::SourceParser.after_parse_list { run_callbacks }
     end
 
     def parse(files = nil, &block)
-      unless @parsing
-        @parsing = true
+      @parsing.synchronize do
         @after_parse_once_callbacks << block if block
         files_list = files ? files.select { |file| file.to_s.end_with?(".rb") } : paths
 
@@ -43,7 +42,6 @@ module Lookbook
     def run_callbacks
       callbacks.each { |cb| cb.call(YARD::Registry) }
       @after_parse_once_callbacks = []
-      @parsing = false
     end
 
     def define_tags(tags = nil)


### PR DESCRIPTION
Closes https://github.com/lookbook-hq/lookbook/issues/699

**Context:** When `lazy_load_previews_and_pages` is enabled, [the initial loading of previews is delayed until they are first requested](https://github.com/lookbook-hq/lookbook/blob/e27bbe852e325f0046c04ec4a04e70b3c74be9ee/lib/lookbook/engine.rb#L239-L253).

**Problem:** The existing preview parsing logic uses an instance variable as a boolean flag to prevent concurrent parsing operations. However, this approach has two issues:
1. It's not truly atomic, creating potential race conditions
2. When a second thread attempts to parse while another is already parsing, it simply skips parsing entirely rather than waiting

This race condition is primarily exposed when `lazy_load_previews_and_pages` is enabled. If a "parse changed files" operation is already running when an initial parse request comes in, the initial parse gets skipped entirely. Since no files have actually changed, nothing gets parsed, resulting in an empty preview collection.

Without this config, you'd need to be reloading while preview files are changing to encounter the same issue.

**Solution:** Replace the boolean flag with a mutex to ensure:
- Only one parsing operation executes at a time (thread-safe)
- Queued parse requests are executed rather than skipped, keeping the collection up to date