### PR TITLE
Fix headings IDs in markdown pages

### DIFF
--- a/config/app.yml
+++ b/config/app.yml
@@ -35,16 +35,13 @@ shared:
   page_extensions: [html.*, md.*]
   page_options: {}
 
-  markdown_extensions:
+  markdown_options:
     tables: true
     fenced_code_blocks: true
     disable_indented_code_blocks: true
     strikethrough: true
     highlight: true
     lax_spacing: true
-
-  markdown_options:
-    with_toc_data: true
 
   highlighter_options:
     theme: github

--- a/docs/src/_data/config_options.yml
+++ b/docs/src/_data/config_options.yml
@@ -207,28 +207,28 @@ theming:
       Customise or disable the favicon served by Lookbook.
 
 markdown:
-  - name: markdown_extensions.tables
+  - name: markdown_options.tables
     types: Boolean
     default: "true"
-    example: config.lookbook.markdown_extensions.tables = false
+    example: config.lookbook.markdown_options.tables = false
     description: Enable/disable support for tables
 
-  - name: markdown_extensions.fenced_code_blocks
+  - name: markdown_options.fenced_code_blocks
     types: Boolean
     default: "true"
-    example: config.lookbook.markdown_extensions.fenced_code_blocks = false
+    example: config.lookbook.markdown_options.fenced_code_blocks = false
     description: Enable/disable support for fenced code blocks
 
-  - name: markdown_extensions.disable_indented_code_blocks
+  - name: markdown_options.disable_indented_code_blocks
     types: Boolean
     default: "true"
-    example: config.lookbook.markdown_extensions.disable_indented_code_blocks = false
+    example: config.lookbook.markdown_options.disable_indented_code_blocks = false
     description: Enable/disable support for indented code blocks
 
-  - name: markdown_extensions.lax_spacing
+  - name: markdown_options.lax_spacing
     types: Boolean
     default: "true"
-    example: config.lookbook.markdown_extensions.lax_spacing = false
+    example: config.lookbook.markdown_options.lax_spacing = false
     description: Enable/disable support for lax spacing
 
 highlighter:

--- a/lib/lookbook/services/markdown_renderer.rb
+++ b/lib/lookbook/services/markdown_renderer.rb
@@ -2,17 +2,18 @@ require "redcarpet"
 
 module Lookbook
   class MarkdownRenderer < Service
-    attr_reader :text, :extensions, :opts
+    attr_reader :text, :extensions, :options
 
-    def initialize(text, opts = {})
+    # In Lookbook config, `markdown_options` are actually Redcarpet `extensions` so we store them as `@extensions`
+    def initialize(text, extensions = {}, options = {})
       @text = text
-      @extensions = Lookbook.config.markdown_extensions
-      @opts = Lookbook.config.markdown_options.merge(opts.to_h)
+      @extensions = Lookbook.config.markdown_options.merge(extensions.to_h)
+      @options = default_options.merge(options.to_h)
     end
 
     def call
       clean_text = ActionViewAnnotationsStripper.call(text)
-      md = Redcarpet::Markdown.new(LookbookMarkdownRenderer.new(opts), extensions)
+      md = Redcarpet::Markdown.new(LookbookMarkdownRenderer.new(default_options), extensions)
       md.render(clean_text).html_safe
     end
 
@@ -29,6 +30,12 @@ module Lookbook
         full_document&.gsub!("</lookbook-embed></p>", "</lookbook-embed>")
         full_document
       end
+    end
+
+    def default_options
+      {
+        with_toc_data: true
+      }
     end
   end
 end

--- a/lib/lookbook/stores/config_store.rb
+++ b/lib/lookbook/stores/config_store.rb
@@ -51,10 +51,6 @@ module Lookbook
       store[:listen_extensions].push(*extensions.to_a).uniq!
     end
 
-    def markdown_extensions=(extensions = nil)
-      store[:markdown_extensions].merge!(extensions.to_h)
-    end
-
     def markdown_options=(options = nil)
       store[:markdown_options].merge!(options.to_h)
     end

--- a/spec/lib/stores/config_store_spec.rb
+++ b/spec/lib/stores/config_store_spec.rb
@@ -162,45 +162,24 @@ RSpec.describe Lookbook::ConfigStore do
         end
       end
 
-      context "markdown_extensions" do
-        it "is a hash of extensions" do
-          expect(config.markdown_extensions).to be_a Hash
-        end
-
-        it "can have an individual value changed" do
-          config.markdown_extensions.tables = false
-
-          expect(config.markdown_extensions.tables).to be false
-        end
-
-        it "merges existing extensions when set as a hash" do
-          config.markdown_extensions = {
-            tables: false
-          }
-
-          expect(config.markdown_extensions.tables).to be false
-          expect(config.markdown_extensions.fenced_code_blocks).to be true
-        end
-      end
-
       context "markdown_options" do
         it "is a hash of options" do
           expect(config.markdown_options).to be_a Hash
         end
 
         it "can have an individual value changed" do
-          config.markdown_options.with_toc_data = false
+          config.markdown_options.tables = false
 
-          expect(config.markdown_options.with_toc_data).to be false
+          expect(config.markdown_options.tables).to be false
         end
 
         it "merges existing options when set as a hash" do
           config.markdown_options = {
-            prettify: false
+            tables: false
           }
 
-          expect(config.markdown_options.prettify).to be false
-          expect(config.markdown_options.with_toc_data).to be true
+          expect(config.markdown_options.tables).to be false
+          expect(config.markdown_options.fenced_code_blocks).to be true
         end
       end
 


### PR DESCRIPTION
I needed to separate Redcarpet's markdown "[extensions](https://github.com/vmg/redcarpet?tab=readme-ov-file#and-its-like-really-simple-to-use)" (such as `tables` and `fenced_code_blocks`) from "[render options](https://github.com/vmg/redcarpet?tab=readme-ov-file#darling-i-packed-you-a-couple-renderers-for-lunch)" (such as `with_toc_data`).

This is a breaking change since Lookbook's `markdown_options` config is renamed `markdown_extensions`. Or should we keep a single `markdown_options`, but automatically filter out `extensions`?

What do you think @allmarkedup?

Close #721