### PR TITLE
Fix unresponsive params panel bug

### DIFF
--- a/app/controllers/lookbook/application_controller.rb
+++ b/app/controllers/lookbook/application_controller.rb
@@ -10,6 +10,9 @@ module Lookbook
     helper Lookbook::ApplicationHelper
     helper Lookbook::UiElementsHelper
 
+    before_action :disable_annotations
+    after_action :restore_annotations
+
     before_action :assign_theme_overrides
     before_action :assign_instance_vars
 
@@ -36,6 +39,20 @@ module Lookbook
     end
 
     protected
+
+    def disable_annotations
+      return unless ActionView::Base.respond_to?(:annotate_rendered_view_with_filenames)
+
+      @original_annotations_value = ActionView::Base.annotate_rendered_view_with_filenames
+      ActionView::Base.annotate_rendered_view_with_filenames = false
+    end
+
+    def restore_annotations
+      return if @original_annotations_value.nil?
+
+      ActionView::Base.annotate_rendered_view_with_filenames = @original_annotations_value
+      @original_annotations_value = nil
+    end
 
     def assign_theme_overrides
       @theme_overrides ||= Engine.theme.to_css


### PR DESCRIPTION
Fixes #735. 

ActionView template annotation comments (when enabled) were causing DOM morphing issues when updating the params panel. This fix disables them before all Lookbook controller actions and re-enables them when the actions are finished.

They can't just be disabled and left like that because there is no way to scope configuration items like these to a specific engine and we don't want to inadvertently affect the expected configuration of the host app.