### PR TITLE
Use a reentrant lock in the preview parser

### DIFF
--- a/lib/lookbook/preview_parser.rb
+++ b/lib/lookbook/preview_parser.rb
@@ -6,7 +6,7 @@ module Lookbook
       @paths = paths
       @after_parse_callbacks = []
       @after_parse_once_callbacks = []
-      @parsing = Mutex.new
+      @parsing = Monitor.new
 
       define_tags(tags)
       YARD::Parser::SourceParser.after_parse_list { run_callbacks }


### PR DESCRIPTION
In https://github.com/lookbook-hq/lookbook/pull/718, a mutex was added to the PreviewParser to ensure only one thread updates the previews at the same time (particularly when `lazy_load_previews_and_pages` is enabled). Unfortunately `Mutex` locks are not reentrant. If a reload is triggered due to a lookbook preview file change, and the previews have not been previously loaded then you get nested calls to `load_previews`, which results in a `deadlock; recursive locking` exception.

The simplest change to fix the issue is to use a `Monitor` rather than a `Mutex`, which is reentrant and matches the previous behaviour before https://github.com/lookbook-hq/lookbook/pull/718.

```rb
> m = Mutex.new
> m.synchronize { m.synchronize { puts 'hi' } }
ThreadError: deadlock; recursive locking (ThreadError)

> m = Monitor.new
> m.synchronize { m.synchronize { puts 'hi' } }
hi
```

I have not added any specs for this. I couldn't find an obvious place to put them. But I have tested this locally with my rails app using the following steps and it does fix the problem:

1. Start the rails app
2. Load a page unrelated to lookbook
3. Update a lookbook preview file
4. Reload the page
    1. Before the change: `deadlock; recursive locking`
    2. After the change: loads fine

<details><summary>stacktrace</summary>
<code><pre>lookbook (2.3.12) lib/lookbook/preview_parser.rb:16:in 'Thread::Mutex#synchronize'
lookbook (2.3.12) lib/lookbook/preview_parser.rb:16:in 'Lookbook::PreviewParser#parse'
lookbook (2.3.12) lib/lookbook/engine.rb:262:in 'Lookbook::Engine.load_previews'
lookbook (2.3.12) lib/lookbook/reloaders.rb:69:in 'block in Lookbook::Reloaders::Reloader#file_watcher'
activesupport (8.0.2.1) lib/active_support/evented_file_update_checker.rb:61:in 'ActiveSupport::EventedFileUpdateChecker#execute'
lookbook (2.3.12) lib/lookbook/reloaders.rb:35:in 'Lookbook::Reloaders::Reloader#execute'
lookbook (2.3.12) lib/lookbook/reloaders.rb:25:in 'block in Lookbook::Reloaders#execute'
lookbook (2.3.12) lib/lookbook/reloaders.rb:24:in 'Array#each'
lookbook (2.3.12) lib/lookbook/reloaders.rb:24:in 'Lookbook::Reloaders#execute'
lookbook (2.3.12) lib/lookbook/engine.rb:246:in 'Lookbook::Engine.previews'
lookbook (2.3.12) lib/lookbook/engine.rb:263:in 'block in Lookbook::Engine.load_previews'
lookbook (2.3.12) lib/lookbook/preview_parser.rb:43:in 'block in Lookbook::PreviewParser#run_callbacks'
lookbook (2.3.12) lib/lookbook/preview_parser.rb:43:in 'Array#each'
lookbook (2.3.12) lib/lookbook/preview_parser.rb:43:in 'Lookbook::PreviewParser#run_callbacks'
lookbook (2.3.12) lib/lookbook/preview_parser.rb:12:in 'block in Lookbook::PreviewParser#initialize'
yard (0.9.37) lib/yard/parser/source_parser.rb:374:in 'block in YARD::Parser::SourceParser.parse_in_order'
yard (0.9.37) lib/yard/parser/source_parser.rb:373:in 'Array#each'
yard (0.9.37) lib/yard/parser/source_parser.rb:373:in 'YARD::Parser::SourceParser.parse_in_order'
yard (0.9.37) lib/yard/parser/source_parser.rb:114:in 'block in YARD::Parser::SourceParser.parse'
yard (0.9.37) lib/yard/logging.rb:145:in 'YARD::Logger#enter_level'
yard (0.9.37) lib/yard/parser/source_parser.rb:113:in 'YARD::Parser::SourceParser.parse'
yard (0.9.37) lib/yard.rb:20:in 'YARD.parse'
lookbook (2.3.12) lib/lookbook/preview_parser.rb:21:in 'block in Lookbook::PreviewParser#parse'
lookbook (2.3.12) lib/lookbook/preview_parser.rb:16:in 'Thread::Mutex#synchronize'
lookbook (2.3.12) lib/lookbook/preview_parser.rb:16:in 'Lookbook::PreviewParser#parse'
lookbook (2.3.12) lib/lookbook/engine.rb:262:in 'Lookbook::Engine.load_previews'
lookbook (2.3.12) lib/lookbook/reloaders.rb:69:in 'block in Lookbook::Reloaders::Reloader#file_watcher'
activesupport (8.0.2.1) lib/active_support/evented_file_update_checker.rb:61:in 'ActiveSupport::EventedFileUpdateChecker#execute'
activesupport (8.0.2.1) lib/active_support/evented_file_update_checker.rb:67:in 'ActiveSupport::EventedFileUpdateChecker#execute_if_updated'
lookbook (2.3.12) lib/lookbook/reloaders.rb:35:in 'Lookbook::Reloaders::Reloader#execute_if_updated'
lookbook (2.3.12) lib/lookbook/reloaders.rb:17:in 'block in Lookbook::Reloaders#add'
activesupport (8.0.2.1) lib/active_support/callbacks.rb:406:in 'BasicObject#instance_exec'
activesupport (8.0.2.1) lib/active_support/callbacks.rb:406:in 'block in ActiveSupport::Callbacks::CallTemplate::InstanceExec0#make_lambda'
activesupport (8.0.2.1) lib/active_support/callbacks.rb:178:in 'block in ActiveSupport::Callbacks::Filters::Before#call'
activesupport (8.0.2.1) lib/active_support/callbacks.rb:668:in 'block (2 levels) in ActiveSupport::Callbacks::CallbackChain#default_terminator'
activesupport (8.0.2.1) lib/active_support/callbacks.rb:667:in 'Kernel#catch'
activesupport (8.0.2.1) lib/active_support/callbacks.rb:667:in 'block in ActiveSupport::Callbacks::CallbackChain#default_terminator'
activesupport (8.0.2.1) lib/active_support/callbacks.rb:179:in 'ActiveSupport::Callbacks::Filters::Before#call'
activesupport (8.0.2.1) lib/active_support/callbacks.rb:559:in 'block in ActiveSupport::Callbacks::CallbackSequence#invoke_before'
activesupport (8.0.2.1) lib/active_support/callbacks.rb:559:in 'Array#each'
activesupport (8.0.2.1) lib/active_support/callbacks.rb:559:in 'ActiveSupport::Callbacks::CallbackSequence#invoke_before'
activesupport (8.0.2.1) lib/active_support/callbacks.rb:108:in 'ActiveSupport::Callbacks#run_callbacks'
activesupport (8.0.2.1) lib/active_support/execution_wrapper.rb:128:in 'ActiveSupport::ExecutionWrapper#run'
activesupport (8.0.2.1) lib/active_support/execution_wrapper.rb:124:in 'ActiveSupport::ExecutionWrapper#run!'
activesupport (8.0.2.1) lib/active_support/reloader.rb:122:in 'ActiveSupport::Reloader#run!'
</pre></code>
</details>