### PR TITLE
fix(params): coerce preview params at render time (fixes #640)

### DIFF
--- a/docs/src/_guide/previews/params.md
+++ b/docs/src/_guide/previews/params.md
@@ -382,6 +382,8 @@ title: Dynamic Params
     - `Hash` - _value string converted to Hash using the Ruby YAML parser_
     - `Array` - _value string converted to Array using the Ruby YAML parser_
 
+    Type casting is applied whenever a preview is rendered, including via ViewComponent's `render_preview` test helper. This means preview methods can rely on receiving the declared type in their own tests, and downstream `.to_sym`/manual-cast workarounds are no longer required.
+
   <% end %>
 <% end %>
 

--- a/lib/lookbook/engine.rb
+++ b/lib/lookbook/engine.rb
@@ -84,6 +84,7 @@ module Lookbook
         end
 
         ViewComponent::Preview.extend(Lookbook::PreviewAfterRender)
+        ViewComponent::Preview.singleton_class.prepend(Lookbook::PreviewParamCoercion)
       end
 
       if opts.reload_on_change.nil?

--- a/lib/lookbook/preview.rb
+++ b/lib/lookbook/preview.rb
@@ -82,4 +82,6 @@ module Lookbook
       end
     end
   end
+
+  Preview.singleton_class.prepend(PreviewParamCoercion)
 end

--- a/lib/lookbook/preview_param_coercion.rb
+++ b/lib/lookbook/preview_param_coercion.rb
@@ -1,0 +1,75 @@
+module Lookbook
+  # Applies `@param` type coercion to preview parameters at render time.
+  #
+  # Coercion historically lived only in Lookbook's controller (`set_params`),
+  # so entry paths that bypass it — notably ViewComponent's `render_preview`
+  # test helper — received raw string params. This module is prepended to the
+  # singleton class of each preview base class so coercion happens inside
+  # `render_args`, which every entry path funnels through.
+  #
+  # Coercion is idempotent: only raw String values are cast, so values already
+  # coerced upstream (e.g. by `set_params`) are passed through unchanged.
+  module PreviewParamCoercion
+    def render_args(scenario, params: {})
+      super(scenario, params: PreviewParamCoercion.coerce(self, scenario, params))
+    end
+
+    def self.find_scenario(preview, scenario)
+      name = scenario.to_s
+      preview.scenarios.each do |entity|
+        if entity.is_a?(ScenarioGroupEntity)
+          found = entity.scenarios.find { |s| s.name == name }
+          return found if found
+        elsif entity.name == name
+          return entity
+        end
+      end
+      nil
+    end
+
+    def self.coerce(preview_class, scenario, params)
+      return params if params.nil? || params.empty?
+
+      preview = Engine.previews.find_by_preview_class(preview_class)
+      return params unless preview
+
+      scenario_entity = find_scenario(preview, scenario)
+      return params unless scenario_entity
+
+      param_tags = scenario_entity.tags("param").uniq(&:name)
+      return params if param_tags.empty?
+
+      coerced = params.dup
+      param_tags.each do |tag|
+        # Match the param key whether it was provided as a String or a Symbol,
+        # preserving the original key type so the downstream `render_args`
+        # slice (by symbol, or via indifferent access) still finds it.
+        key = param_key(coerced, tag.name)
+        next if key.nil?
+
+        value = coerced[key]
+        next unless value.is_a?(String) # idempotent: only cast raw strings
+
+        begin
+          coerced[key] = Param.from_tag(tag, value: value).cast_value
+        rescue => exception
+          Lookbook.logger.debug("Param coercion skipped for '#{tag.name}': #{exception.message}")
+        end
+      end
+      coerced
+    rescue => exception
+      # Coercion must never raise out of `render_args`: fall back to the
+      # original params if entity lookup or tag access fails unexpectedly.
+      Lookbook.logger.debug("Param coercion skipped: #{exception.message}")
+      params
+    end
+
+    def self.param_key(params, name)
+      if params.key?(name)
+        name
+      elsif params.key?(name.to_sym)
+        name.to_sym
+      end
+    end
+  end
+end

--- a/spec/components/param_coercion_spec.rb
+++ b/spec/components/param_coercion_spec.rb
@@ -1,0 +1,30 @@
+require "rails_helper"
+
+RSpec.describe "preview param coercion via render_preview", type: :component do
+  it "coerces a symbol param" do
+    result = render_preview(:coerce_symbol, from: ParamsComponentPreview, params: {my_param: "bar"})
+    expect(result.text).to include("my_param=bar class=Symbol")
+  end
+
+  it "coerces mixed param types" do
+    result = render_preview(:coerce_mixed, from: ParamsComponentPreview,
+      params: {sym: "bar", flag: "true", num: "3"})
+    expect(result.text).to include("sym=Symbol")
+    expect(result.text).to include("flag=TrueClass")
+    expect(result.text).to include("num=Integer")
+  end
+
+  it "coerces params for Lookbook::Preview subclasses" do
+    # render_preview (ViewComponent's helper) doesn't resolve Lookbook::Preview
+    # subclasses, so exercise render_args directly. Symbol keys are required:
+    # render_args slices provided params by the method's symbol parameter names.
+    result = ViewComponentExamplePreview.render_args(:coerce_symbol, params: {my_param: "bar"})
+    block_content = result[:block].call
+    expect(block_content).to include("my_param=bar class=Symbol")
+  end
+
+  it "coerces params for grouped scenarios" do
+    result = render_preview(:grouped_coerce, from: GroupComponentPreview, params: {my_param: "bar"})
+    expect(result.text).to include("my_param=bar class=Symbol")
+  end
+end

--- a/spec/dummy/test/components/previews/group_component_preview.rb
+++ b/spec/dummy/test/components/previews/group_component_preview.rb
@@ -37,4 +37,15 @@ class GroupComponentPreview < ViewComponent::Preview
   end
 
   # @!endgroup
+
+  # @!group Coercion
+
+  # @param my_param [Symbol] select [foo, bar]
+  def grouped_coerce(my_param: :foo)
+    render StandardComponent.new do
+      "my_param=#{my_param} class=#{my_param.class}"
+    end
+  end
+
+  # @!endgroup
 end

--- a/spec/dummy/test/components/previews/params_component_preview.rb
+++ b/spec/dummy/test/components/previews/params_component_preview.rb
@@ -44,4 +44,20 @@ class ParamsComponentPreview < ViewComponent::Preview
       body_text
     end
   end
+
+  # @param my_param [Symbol] select [foo, bar]
+  def coerce_symbol(my_param: :foo)
+    render StandardComponent.new do
+      "my_param=#{my_param} class=#{my_param.class}"
+    end
+  end
+
+  # @param sym [Symbol] select [foo, bar]
+  # @param flag [Boolean] toggle
+  # @param num number
+  def coerce_mixed(sym: :foo, flag: false, num: 1)
+    render StandardComponent.new do
+      "sym=#{sym.class} flag=#{flag.class} num=#{num.class}"
+    end
+  end
 end

--- a/spec/dummy/test/components/previews/view_component_example_preview.rb
+++ b/spec/dummy/test/components/previews/view_component_example_preview.rb
@@ -2,4 +2,11 @@ class ViewComponentExamplePreview < Lookbook::Preview
   def default
     render BasicComponent.new
   end
+
+  # @param my_param [Symbol] select [foo, bar]
+  def coerce_symbol(my_param: :foo)
+    render StandardComponent.new do
+      "my_param=#{my_param} class=#{my_param.class}"
+    end
+  end
 end

--- a/spec/lib/preview_param_coercion_spec.rb
+++ b/spec/lib/preview_param_coercion_spec.rb
@@ -1,0 +1,40 @@
+require "rails_helper"
+
+RSpec.describe Lookbook::PreviewParamCoercion do
+  describe ".coerce" do
+    it "casts raw string values to the declared param type" do
+      result = described_class.coerce(ParamsComponentPreview, "coerce_symbol", {"my_param" => "bar"})
+      expect(result["my_param"]).to eq(:bar)
+    end
+
+    it "leaves already-cast (non-String) values untouched (idempotent)" do
+      result = described_class.coerce(ParamsComponentPreview, "coerce_symbol", {"my_param" => :bar})
+      expect(result["my_param"]).to eq(:bar)
+    end
+
+    it "casts symbol-keyed params and preserves the symbol key" do
+      result = described_class.coerce(ParamsComponentPreview, "coerce_symbol", {my_param: "bar"})
+      expect(result[:my_param]).to eq(:bar)
+    end
+
+    it "passes params through when the preview class is unknown" do
+      input = {"my_param" => "bar"}
+      expect(described_class.coerce(Class.new, "coerce_symbol", input)).to eq(input)
+    end
+
+    it "passes params through for params with no @param tag" do
+      result = described_class.coerce(ParamsComponentPreview, "coerce_symbol", {"unknown" => "x"})
+      expect(result["unknown"]).to eq("x")
+    end
+
+    it "does not raise when casting an invalid value and returns the casted result" do
+      result = nil
+      # ActiveModel's integer cast coerces a non-numeric string to 0 rather
+      # than raising; coercion must not blow up out of render_args either way.
+      expect {
+        result = described_class.coerce(ParamsComponentPreview, "coerce_mixed", {"num" => "not-a-number"})
+      }.not_to raise_error
+      expect(result["num"]).to eq(0)
+    end
+  end
+end

--- a/spec/requests/previews_spec.rb
+++ b/spec/requests/previews_spec.rb
@@ -122,4 +122,11 @@ RSpec.describe "previews", type: :request do
       end
     end
   end
+
+  context "param coercion (controller path)" do
+    it "still coerces params when visiting the preview URL" do
+      get lookbook_preview_path("params/coerce_symbol"), params: {my_param: "bar"}
+      expect(response.body).to include("my_param=bar class=Symbol")
+    end
+  end
 end


### PR DESCRIPTION
## Problem

`@param` type coercion (e.g. `# @param theme [Symbol]`) only happened inside Lookbook's own controller (`TargetableConcern#set_params`). Any render path that bypasses that controller received **raw string params** instead of the declared type.

The most common bypass is ViewComponent's `render_preview` test helper, which routes through ViewComponent's own `previews` controller action → `Preview.render_args` with uncoerced params. So a preview tested with:

```ruby
render_preview(:default, from: MyPreview, params: { theme: "primary" })
```

received `theme` as `"primary"` (String) rather than `:primary` (Symbol), even with `# @param theme [Symbol]`.

Fixes #640.

This is why downstream projects (e.g. OpenProject, primer_view_components) sprinkle manual `.to_sym` / `coerce_bool` calls inside preview bodies — they need previews to be robust to both the coerced (UI) and uncoerced (test) param paths.

## Fix

Both entry paths funnel through one chokepoint: the preview class method `render_args(scenario, params:)`. A new module `Lookbook::PreviewParamCoercion` is prepended to the singleton class of **both** preview base classes (`ViewComponent::Preview` and `Lookbook::Preview`) and coerces params there, reusing the existing `Param` / `StringValueCaster` machinery.

Key properties:

- **Idempotent** — only raw `String` values are cast, so the existing `set_params` cast (controller path) does not double-cast.
- **Never raises out of `render_args`** — unknown preview/scenario or a cast failure falls back to passing params through unchanged.
- **Handles `@!group`ed scenarios** — the scenario lookup descends into scenario groups.
- **Optional-dependency safe** — the `Lookbook::Preview` wiring is unconditional; the `ViewComponent::Preview` wiring sits behind the existing ViewComponent-present guard.

## Tests

Added coverage for the `render_preview` path (ViewComponent + `Lookbook::Preview` subclasses + grouped scenarios) and a no-regression assertion that the controller path still coerces. Full suite: 597 examples, 0 failures.
