### PR TITLE
Fix XSS in display options field alpine data interpolation

### DIFF
--- a/app/components/lookbook/display_options/field/component.rb
+++ b/app/components/lookbook/display_options/field/component.rb
@@ -17,7 +17,9 @@ module Lookbook
       protected
 
       def alpine_data
-        "{name: '#{name}', value: '#{value}'}"
+        escaped_name = html_escape(json_escape(name.to_s))
+        escaped_value = html_escape(json_escape(value.to_s).gsub("\n", '\n'))
+        "{name: \"#{escaped_name}\", value: \"#{escaped_value}\"}"
       end
 
       def alpine_component


### PR DESCRIPTION
Related issue: https://github.com/github/primer/issues/6759

Closes https://github.com/lookbook-hq/lookbook/issues/802

Similar to: https://github.com/lookbook-hq/lookbook/pull/668

Fixes an XSS vulnerability in `Lookbook::DisplayOptions::Field::Component#alpine_data`, where the `name` and `value` of a display option were interpolated directly into an Alpine.js `x-data` attribute without escaping.

Opening a public PR here since the overall risk is `low to none` (the affected surface is the local Lookbook dev UI, with no auth/sensitive data on the reported deployment).

