### PR TITLE
Asset pipeline support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,4 +17,5 @@ group :test do
   gem "selenium-webdriver", "4.17.0"
   gem "puma", "~> 6"
   gem "rspec-rails", "~> 6"
+  gem "sprockets-rails", "~> 3.5" # For asset pipeline testing
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,7 +5,7 @@ PATH
       activemodel
       css_parser
       htmlbeautifier (~> 1.3)
-      htmlentities (~> 4.3.4)
+      htmlentities (~> 4.3)
       marcel (~> 1.0)
       railties (>= 5.0)
       redcarpet (~> 3.5)
@@ -275,6 +275,14 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
+    sprockets (4.2.2)
+      concurrent-ruby (~> 1.0)
+      logger
+      rack (>= 2.2.4, < 4)
+    sprockets-rails (3.5.2)
+      actionpack (>= 6.1)
+      activesupport (>= 6.1)
+      sprockets (>= 3.0.0)
     standard (1.50.0)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.0)
@@ -330,6 +338,7 @@ DEPENDENCIES
   rails (~> 8.0.0)
   rspec-rails (~> 6)
   selenium-webdriver (= 4.17.0)
+  sprockets-rails (~> 3.5)
   standard
   view_component (= 4.0.0.alpha6)
   yard-activesupport-concern

--- a/app/components/lookbook/icon/component.html.erb
+++ b/app/components/lookbook/icon/component.html.erb
@@ -1,5 +1,5 @@
 <%= render_component_tag :i, style: "height: #{size_rems}; width: #{size_rems}; #{@html_attrs[:style]}", class: "icon-stroke-#{stroke}" do %>
   <svg>
-    <use href="/lookbook-assets/img/lucide-sprite.svg#<%= @icon_name %>"></use>
+    <use href="<%= sprite_path %>#<%= @icon_name %>"></use>
   </svg>
 <% end %>

--- a/app/components/lookbook/icon/component.rb
+++ b/app/components/lookbook/icon/component.rb
@@ -14,5 +14,13 @@ module Lookbook
     def size_rems
       "#{@size * 0.25}rem"
     end
+
+    def sprite_path
+      if defined? helpers.lookbook_asset_path
+        helpers.lookbook_asset_path("img/lucide-sprite.svg")
+      else
+        "/lookbook-assets/img/lucide-sprite.svg"
+      end
+    end
   end
 end

--- a/app/helpers/lookbook/application_helper.rb
+++ b/app/helpers/lookbook/application_helper.rb
@@ -1,11 +1,10 @@
 module Lookbook
   module ApplicationHelper
     def lookbook_asset_path(file, version: true)
-      # In production with asset_host configured, serve from CDN
-      # Assets are copied to public/assets/lookbook-assets/ during precompilation
-      if Rails.env.production? &&
-         Rails.application.config.action_controller.respond_to?(:asset_host) &&
-         Rails.application.config.action_controller.asset_host.present?
+      # When the host app has an asset_host configured, assets are being served from
+      # a CDN. Assets are copied to public/assets/lookbook-assets/ during precompilation
+      if Rails.application.config.action_controller.respond_to?(:asset_host) &&
+          Rails.application.config.action_controller.asset_host.present?
 
         asset_host = Rails.application.config.action_controller.asset_host
         file_path = file.to_s.sub(%r{^/}, "")

--- a/app/helpers/lookbook/application_helper.rb
+++ b/app/helpers/lookbook/application_helper.rb
@@ -2,16 +2,18 @@ module Lookbook
   module ApplicationHelper
     def lookbook_asset_path(file, version: true)
       # When the host app has an asset_host configured, assets are being served from
-      # a CDN. Assets are copied to public/assets/lookbook-assets/ during precompilation
+      # a CDN. Assets are copied alongside the host app's precompiled assets (under
+      # config.assets.prefix) during precompilation.
       if Rails.application.config.action_controller.respond_to?(:asset_host) &&
           Rails.application.config.action_controller.asset_host.present?
 
         asset_host = Rails.application.config.action_controller.asset_host
+        assets_prefix = Rails.application.config.assets.prefix
         file_path = file.to_s.sub(%r{^/}, "")
 
         # Build CDN URL: asset_host already includes release path
         # e.g., https://cdn.example.com/eureka/{release}/assets/lookbook-assets/css/lookbook.css
-        "#{asset_host}/assets/lookbook-assets/#{file_path}#{version ? "?v=#{Lookbook::VERSION}" : ""}"
+        "#{asset_host}#{assets_prefix}/lookbook-assets/#{file_path}#{version ? "?v=#{Lookbook::VERSION}" : ""}"
       else
         # Development: use middleware path
         middleware_path(file, version)

--- a/app/helpers/lookbook/application_helper.rb
+++ b/app/helpers/lookbook/application_helper.rb
@@ -1,20 +1,20 @@
 module Lookbook
   module ApplicationHelper
     def lookbook_asset_path(file, version: true)
-      # Use asset pipeline (Sprockets/Propshaft) when available for CDN support
-      if defined?(::Sprockets) || defined?(::Propshaft)
-        begin
-          # Strip leading slash and use Rails asset pipeline for resolution
-          # This enables digest paths and respects asset_host configuration
-          asset_name = file.to_s.sub(%r{^/}, "")
-          ActionController::Base.helpers.asset_path(asset_name)
-        rescue => e
-          # Fallback to middleware path if asset not found in pipeline
-          Rails.logger.debug "Lookbook asset not found via pipeline: #{file} (#{e.class}), using middleware path"
-          middleware_path(file, version)
-        end
+      # In production with asset_host configured, serve from CDN
+      # Assets are copied to public/assets/lookbook-assets/ during precompilation
+      if Rails.env.production? &&
+         Rails.application.config.action_controller.respond_to?(:asset_host) &&
+         Rails.application.config.action_controller.asset_host.present?
+
+        asset_host = Rails.application.config.action_controller.asset_host
+        file_path = file.to_s.sub(%r{^/}, "")
+
+        # Build CDN URL: asset_host already includes release path
+        # e.g., https://cdn.example.com/eureka/{release}/assets/lookbook-assets/css/lookbook.css
+        "#{asset_host}/assets/lookbook-assets/#{file_path}#{version ? "?v=#{Lookbook::VERSION}" : ""}"
       else
-        # Use middleware path when no asset pipeline is available
+        # Development: use middleware path
         middleware_path(file, version)
       end
     end

--- a/app/helpers/lookbook/application_helper.rb
+++ b/app/helpers/lookbook/application_helper.rb
@@ -1,6 +1,27 @@
 module Lookbook
   module ApplicationHelper
     def lookbook_asset_path(file, version: true)
+      # Use asset pipeline (Sprockets/Propshaft) when available for CDN support
+      if defined?(::Sprockets) || defined?(::Propshaft)
+        begin
+          # Strip leading slash and use Rails asset pipeline for resolution
+          # This enables digest paths and respects asset_host configuration
+          asset_name = file.to_s.sub(%r{^/}, "")
+          ActionController::Base.helpers.asset_path(asset_name)
+        rescue => e
+          # Fallback to middleware path if asset not found in pipeline
+          Rails.logger.debug "Lookbook asset not found via pipeline: #{file} (#{e.class}), using middleware path"
+          middleware_path(file, version)
+        end
+      else
+        # Use middleware path when no asset pipeline is available
+        middleware_path(file, version)
+      end
+    end
+
+    private
+
+    def middleware_path(file, version)
       path = "#{Engine.host_config.relative_url_root}/lookbook-assets/#{file}".gsub("//", "/")
       version ? "#{path}?v=#{Lookbook::VERSION}" : path
     end

--- a/lib/lookbook/engine.rb
+++ b/lib/lookbook/engine.rb
@@ -6,25 +6,13 @@ module Lookbook
 
     config.autoload_paths << File.expand_path(root.join("app/components"))
 
-    # Add Lookbook assets to asset pipeline early, before Sprockets initializes
-    initializer "lookbook.assets.precompile", before: "sprockets.environment" do |app|
-      if app.config.respond_to?(:assets)
-        # Add pre-built assets directory to asset pipeline paths
-        app.config.assets.paths << root.join("public", "lookbook-assets").to_s
+    # Note: Lookbook assets are pre-built and contain modern CSS that Sprockets/Sass cannot process.
+    # Instead of adding them to the asset pipeline, we copy them to public/ during deployment.
+    # See lib/tasks/lookbook_assets.rake for the copy task.
 
-        # Register Lookbook assets for precompilation
-        app.config.assets.precompile += %w[
-          css/lookbook.css
-          css/themes/blue.css
-          css/themes/green.css
-          css/themes/indigo.css
-          css/themes/rose.css
-          css/themes/zinc.css
-          js/index.js
-          js/lookbook.js
-          js/iframe.js
-        ]
-      end
+    # Load rake tasks from the gem
+    rake_tasks do
+      load root.join("lib", "tasks", "lookbook_assets.rake")
     end
 
     initializer "lookbook.assets.serve" do

--- a/lib/lookbook/engine.rb
+++ b/lib/lookbook/engine.rb
@@ -6,6 +6,27 @@ module Lookbook
 
     config.autoload_paths << File.expand_path(root.join("app/components"))
 
+    # Add Lookbook assets to asset pipeline early, before Sprockets initializes
+    initializer "lookbook.assets.precompile", before: "sprockets.environment" do |app|
+      if app.config.respond_to?(:assets)
+        # Add pre-built assets directory to asset pipeline paths
+        app.config.assets.paths << root.join("public", "lookbook-assets").to_s
+
+        # Register Lookbook assets for precompilation
+        app.config.assets.precompile += %w[
+          css/lookbook.css
+          css/themes/blue.css
+          css/themes/green.css
+          css/themes/indigo.css
+          css/themes/rose.css
+          css/themes/zinc.css
+          js/index.js
+          js/lookbook.js
+          js/iframe.js
+        ]
+      end
+    end
+
     initializer "lookbook.assets.serve" do
       config.app_middleware.use(
         Rack::Static,

--- a/lib/lookbook/engine.rb
+++ b/lib/lookbook/engine.rb
@@ -10,11 +10,6 @@ module Lookbook
     # Instead of adding them to the asset pipeline, we copy them to public/ during deployment.
     # See lib/tasks/lookbook_assets.rake for the copy task.
 
-    # Load rake tasks from the gem
-    rake_tasks do
-      load root.join("lib", "tasks", "lookbook_assets.rake")
-    end
-
     initializer "lookbook.assets.serve" do
       config.app_middleware.use(
         Rack::Static,

--- a/lib/tasks/lookbook_assets.rake
+++ b/lib/tasks/lookbook_assets.rake
@@ -1,0 +1,39 @@
+# Rake task to copy Lookbook pre-compiled assets for production deployment
+#
+# Problem: Lookbook's pre-built CSS contains modern syntax that Sprockets' SassCompressor
+# cannot parse (e.g., @media (width >= 480px)). Instead of adding to the asset pipeline,
+# we copy the pre-built assets to public/assets/lookbook-assets/ where they'll be uploaded
+# to CDN alongside other precompiled assets.
+#
+# The assets will be served from CDN in production via the lookbook_asset_path helper.
+
+namespace :lookbook do
+  desc 'Copy Lookbook pre-compiled assets to public/assets/lookbook-assets for CDN deployment'
+  task copy_assets: :environment do
+    require 'fileutils'
+
+    lookbook_source = Lookbook::Engine.root.join('public', 'lookbook-assets')
+    # Copy to public/assets/ so they're included in normal asset deployment
+    public_dest = Rails.public_path.join('assets/lookbook-assets')
+
+    # Remove existing directory to ensure clean copy
+    FileUtils.rm_rf(public_dest) if public_dest.exist?
+
+    # Ensure parent directory exists
+    FileUtils.mkdir_p(public_dest.parent)
+
+    # Copy all Lookbook assets
+    FileUtils.cp_r(lookbook_source, public_dest)
+
+    file_count = Dir.glob(public_dest.join('**', '*')).count { |f| File.file?(f) }
+    puts '✓ Lookbook assets copied to public/assets/lookbook-assets/'
+    puts "  #{file_count} files ready for CDN deployment"
+  end
+end
+
+# Hook into assets:precompile so this runs automatically during deployment
+if Rake::Task.task_defined?('assets:precompile')
+  Rake::Task['assets:precompile'].enhance do
+    Rake::Task['lookbook:copy_assets'].invoke
+  end
+end

--- a/lib/tasks/lookbook_assets.rake
+++ b/lib/tasks/lookbook_assets.rake
@@ -2,19 +2,20 @@
 #
 # Problem: Lookbook's pre-built CSS contains modern syntax that Sprockets' SassCompressor
 # cannot parse (e.g., @media (width >= 480px)). Instead of adding to the asset pipeline,
-# we copy the pre-built assets to public/assets/lookbook-assets/ where they'll be uploaded
-# to CDN alongside other precompiled assets.
+# we copy the pre-built assets alongside the host app's precompiled assets (respecting
+# config.assets.prefix, e.g. some apps serve assets under a custom prefix rather than
+# the Rails default of /assets) so they get picked up by whatever deploys those to CDN.
 #
 # The assets will be served from CDN in production via the lookbook_asset_path helper.
 
 namespace :lookbook do
-  desc 'Copy Lookbook pre-compiled assets to public/assets/lookbook-assets for CDN deployment'
+  desc "Copy Lookbook pre-compiled assets alongside the host app assets for CDN deployment"
   task copy_assets: :environment do
     require 'fileutils'
 
     lookbook_source = Lookbook::Engine.root.join('public', 'lookbook-assets')
-    # Copy to public/assets/ so they're included in normal asset deployment
-    public_dest = Rails.public_path.join('assets/lookbook-assets')
+    assets_prefix = Rails.application.config.assets.prefix.sub(%r{^/}, "")
+    public_dest = Rails.public_path.join(assets_prefix, "lookbook-assets")
 
     # Remove existing directory to ensure clean copy
     FileUtils.rm_rf(public_dest) if public_dest.exist?
@@ -26,7 +27,7 @@ namespace :lookbook do
     FileUtils.cp_r(lookbook_source, public_dest)
 
     file_count = Dir.glob(public_dest.join('**', '*')).count { |f| File.file?(f) }
-    puts '✓ Lookbook assets copied to public/assets/lookbook-assets/'
+    puts "✓ Lookbook assets copied to public/#{assets_prefix}/lookbook-assets/"
     puts "  #{file_count} files ready for CDN deployment"
   end
 end

--- a/spec/lib/asset_pipeline_spec.rb
+++ b/spec/lib/asset_pipeline_spec.rb
@@ -1,0 +1,111 @@
+require "rails_helper"
+
+RSpec.describe "Asset Pipeline Integration" do
+  describe "Sprockets asset paths" do
+    it "includes lookbook assets in the asset pipeline paths" do
+      skip "Dummy app doesn't have Sprockets configured" unless Rails.application.config.respond_to?(:assets)
+
+      lookbook_assets_path = Lookbook::Engine.root.join("public", "lookbook-assets").to_s
+      expect(Rails.application.config.assets.paths).to include(lookbook_assets_path)
+    end
+
+    it "registers lookbook assets for precompilation" do
+      skip "Dummy app doesn't have Sprockets configured" unless Rails.application.config.respond_to?(:assets)
+
+      precompile_list = Rails.application.config.assets.precompile
+
+      expect(precompile_list).to include("css/lookbook.css")
+      expect(precompile_list).to include("js/lookbook.js")
+      expect(precompile_list).to include("js/index.js")
+      expect(precompile_list).to include("js/iframe.js")
+    end
+  end
+
+  describe "lookbook_asset_path helper" do
+    let(:helper) { Class.new { include Lookbook::ApplicationHelper }.new }
+
+    context "when Sprockets is available" do
+      before do
+        # Ensure Sprockets constant is defined
+        stub_const("Sprockets", Module.new) unless defined?(Sprockets)
+      end
+
+      it "uses Rails asset_path for asset resolution" do
+        # Mock ActionController::Base.helpers.asset_path
+        allow(ActionController::Base.helpers).to receive(:asset_path)
+          .with("css/lookbook.css")
+          .and_return("/assets/css/lookbook-abc123.css")
+
+        result = helper.lookbook_asset_path("/css/lookbook.css")
+        expect(result).to eq("/assets/css/lookbook-abc123.css")
+      end
+
+      it "strips leading slash from file path" do
+        allow(ActionController::Base.helpers).to receive(:asset_path)
+          .with("js/lookbook.js")
+          .and_return("/assets/js/lookbook-def456.js")
+
+        result = helper.lookbook_asset_path("/js/lookbook.js")
+        expect(result).to eq("/assets/js/lookbook-def456.js")
+      end
+
+      it "falls back to middleware path if asset not found" do
+        allow(ActionController::Base.helpers).to receive(:asset_path)
+          .and_raise(StandardError.new("Asset not found"))
+
+        result = helper.lookbook_asset_path("/css/missing.css")
+        expect(result).to match(%r{/lookbook-assets/css/missing\.css\?v=})
+      end
+    end
+
+    context "when Propshaft is available" do
+      before do
+        stub_const("Propshaft", Module.new) unless defined?(Propshaft)
+        hide_const("Sprockets") if defined?(Sprockets)
+      end
+
+      it "uses Rails asset_path for asset resolution" do
+        allow(ActionController::Base.helpers).to receive(:asset_path)
+          .with("css/lookbook.css")
+          .and_return("/assets/css/lookbook-xyz789.css")
+
+        result = helper.lookbook_asset_path("/css/lookbook.css")
+        expect(result).to eq("/assets/css/lookbook-xyz789.css")
+      end
+    end
+
+    context "when no asset pipeline is available" do
+      before do
+        hide_const("Sprockets") if defined?(Sprockets)
+        hide_const("Propshaft") if defined?(Propshaft)
+      end
+
+      it "returns middleware path" do
+        result = helper.lookbook_asset_path("/css/lookbook.css")
+        expect(result).to match(%r{/lookbook-assets/css/lookbook\.css\?v=})
+      end
+
+      it "returns path without version when version: false" do
+        result = helper.lookbook_asset_path("/css/lookbook.css", version: false)
+        expect(result).to eq("/lookbook-assets/css/lookbook.css")
+      end
+    end
+
+    context "with asset_host configured" do
+      before do
+        stub_const("Sprockets", Module.new)
+        allow(Rails.application.config.action_controller).to receive(:asset_host)
+          .and_return("https://cdn.example.com/assets")
+      end
+
+      it "uses CDN URL via asset_path" do
+        allow(ActionController::Base.helpers).to receive(:asset_path)
+          .with("css/lookbook.css")
+          .and_return("https://cdn.example.com/assets/css/lookbook-abc123.css")
+
+        result = helper.lookbook_asset_path("/css/lookbook.css")
+        expect(result).to eq("https://cdn.example.com/assets/css/lookbook-abc123.css")
+      end
+    end
+  end
+end

--- a/spec/lib/asset_pipeline_spec.rb
+++ b/spec/lib/asset_pipeline_spec.rb
@@ -41,6 +41,13 @@ RSpec.describe "Asset Pipeline Integration" do
         result = helper.lookbook_asset_path("/css/lookbook.css", version: false)
         expect(result).to eq("https://cdn.example.com/eureka/release-123/assets/lookbook-assets/css/lookbook.css")
       end
+
+      it "respects a custom config.assets.prefix" do
+        allow(Rails.application.config.assets).to receive(:prefix).and_return("/connect/assets")
+
+        result = helper.lookbook_asset_path("/css/lookbook.css")
+        expect(result).to eq("https://cdn.example.com/eureka/release-123/connect/assets/lookbook-assets/css/lookbook.css?v=#{Lookbook::VERSION}")
+      end
     end
   end
 end

--- a/spec/lib/asset_pipeline_spec.rb
+++ b/spec/lib/asset_pipeline_spec.rb
@@ -1,110 +1,45 @@
 require "rails_helper"
 
 RSpec.describe "Asset Pipeline Integration" do
-  describe "Sprockets asset paths" do
-    it "includes lookbook assets in the asset pipeline paths" do
-      skip "Dummy app doesn't have Sprockets configured" unless Rails.application.config.respond_to?(:assets)
-
-      lookbook_assets_path = Lookbook::Engine.root.join("public", "lookbook-assets").to_s
-      expect(Rails.application.config.assets.paths).to include(lookbook_assets_path)
-    end
-
-    it "registers lookbook assets for precompilation" do
-      skip "Dummy app doesn't have Sprockets configured" unless Rails.application.config.respond_to?(:assets)
-
-      precompile_list = Rails.application.config.assets.precompile
-
-      expect(precompile_list).to include("css/lookbook.css")
-      expect(precompile_list).to include("js/lookbook.js")
-      expect(precompile_list).to include("js/index.js")
-      expect(precompile_list).to include("js/iframe.js")
-    end
-  end
-
   describe "lookbook_asset_path helper" do
     let(:helper) { Class.new { include Lookbook::ApplicationHelper }.new }
+    let(:asset_host_config) { Rails.application.config.action_controller }
 
-    context "when Sprockets is available" do
+    context "when no asset_host is configured" do
       before do
-        # Ensure Sprockets constant is defined
-        stub_const("Sprockets", Module.new) unless defined?(Sprockets)
+        allow(asset_host_config).to receive(:asset_host).and_return(nil)
       end
 
-      it "uses Rails asset_path for asset resolution" do
-        # Mock ActionController::Base.helpers.asset_path
-        allow(ActionController::Base.helpers).to receive(:asset_path)
-          .with("css/lookbook.css")
-          .and_return("/assets/css/lookbook-abc123.css")
-
-        result = helper.lookbook_asset_path("/css/lookbook.css")
-        expect(result).to eq("/assets/css/lookbook-abc123.css")
-      end
-
-      it "strips leading slash from file path" do
-        allow(ActionController::Base.helpers).to receive(:asset_path)
-          .with("js/lookbook.js")
-          .and_return("/assets/js/lookbook-def456.js")
-
-        result = helper.lookbook_asset_path("/js/lookbook.js")
-        expect(result).to eq("/assets/js/lookbook-def456.js")
-      end
-
-      it "falls back to middleware path if asset not found" do
-        allow(ActionController::Base.helpers).to receive(:asset_path)
-          .and_raise(StandardError.new("Asset not found"))
-
-        result = helper.lookbook_asset_path("/css/missing.css")
-        expect(result).to match(%r{/lookbook-assets/css/missing\.css\?v=})
-      end
-    end
-
-    context "when Propshaft is available" do
-      before do
-        stub_const("Propshaft", Module.new) unless defined?(Propshaft)
-        hide_const("Sprockets") if defined?(Sprockets)
-      end
-
-      it "uses Rails asset_path for asset resolution" do
-        allow(ActionController::Base.helpers).to receive(:asset_path)
-          .with("css/lookbook.css")
-          .and_return("/assets/css/lookbook-xyz789.css")
-
-        result = helper.lookbook_asset_path("/css/lookbook.css")
-        expect(result).to eq("/assets/css/lookbook-xyz789.css")
-      end
-    end
-
-    context "when no asset pipeline is available" do
-      before do
-        hide_const("Sprockets") if defined?(Sprockets)
-        hide_const("Propshaft") if defined?(Propshaft)
-      end
-
-      it "returns middleware path" do
+      it "returns the middleware path" do
         result = helper.lookbook_asset_path("/css/lookbook.css")
         expect(result).to match(%r{/lookbook-assets/css/lookbook\.css\?v=})
       end
 
-      it "returns path without version when version: false" do
+      it "returns a path without a version query string when version: false" do
         result = helper.lookbook_asset_path("/css/lookbook.css", version: false)
         expect(result).to eq("/lookbook-assets/css/lookbook.css")
       end
     end
 
-    context "with asset_host configured" do
+    context "when an asset_host is configured" do
       before do
-        stub_const("Sprockets", Module.new)
-        allow(Rails.application.config.action_controller).to receive(:asset_host)
-          .and_return("https://cdn.example.com/assets")
+        allow(asset_host_config).to receive(:asset_host)
+          .and_return("https://cdn.example.com/eureka/release-123")
       end
 
-      it "uses CDN URL via asset_path" do
-        allow(ActionController::Base.helpers).to receive(:asset_path)
-          .with("css/lookbook.css")
-          .and_return("https://cdn.example.com/assets/css/lookbook-abc123.css")
-
+      it "builds a CDN URL under assets/lookbook-assets" do
         result = helper.lookbook_asset_path("/css/lookbook.css")
-        expect(result).to eq("https://cdn.example.com/assets/css/lookbook-abc123.css")
+        expect(result).to eq("https://cdn.example.com/eureka/release-123/assets/lookbook-assets/css/lookbook.css?v=#{Lookbook::VERSION}")
+      end
+
+      it "strips a leading slash from the file path" do
+        result = helper.lookbook_asset_path("/js/lookbook.js")
+        expect(result).to eq("https://cdn.example.com/eureka/release-123/assets/lookbook-assets/js/lookbook.js?v=#{Lookbook::VERSION}")
+      end
+
+      it "omits the version query string when version: false" do
+        result = helper.lookbook_asset_path("/css/lookbook.css", version: false)
+        expect(result).to eq("https://cdn.example.com/eureka/release-123/assets/lookbook-assets/css/lookbook.css")
       end
     end
   end

--- a/spec/support/combustion.rb
+++ b/spec/support/combustion.rb
@@ -1,9 +1,14 @@
 Combustion.path = "spec/dummy"
-Combustion.initialize! :action_controller, :action_view do
+Combustion.initialize! :action_controller, :action_view, :sprockets do
   config.autoloader = :zeitwerk
 
   ActiveSupport::Deprecation.silenced = true if ActiveSupport::Deprecation.respond_to?(:silenced=)
   ActiveSupport::Dependencies.autoload_paths << "#{root}/app"
+
+  # Configure asset pipeline for testing
+  config.assets.enabled = true
+  config.assets.paths = []
+  config.assets.precompile = []
 
   if config.view_component.preview_paths.present?
     config.view_component.preview_paths << "test/components/previews"


### PR DESCRIPTION
#### What's this PR do?

Adds CDN support to `lookbook_asset_path` so Lookbook's pre-built CSS/JS/image assets can be served from a host app's CDN in production, instead of only via the gem's built-in Rack::Static middleware. 

Also fixes the icon component to route its SVG sprite through that same helper instead of a hardcoded path.

#### Why is it needed?

Host apps that serve assets from a CDN (via `config.action_controller.asset_host`) had no way to get Lookbook's own assets onto that CDN, they were only ever served from the gem's in-process middleware, which doesn't work once a host app is actually accessed through a CDN in front of the app.

#### Where should the reviewer start?

Start with `app/helpers/lookbook/application_helper.rb` is has `lookbook_asset_path` which is the core of this change (CDN URL vs. middleware fallback), and once that logic makes sense, `lib/tasks/lookbook_assets.rake` (how the assets actually get onto disk for deploy) and the icon component's use of the same helper both follow naturally from it.

#### How should this be manually tested?

This is currently on staging 2

https://stg-02.studiosity.com/connect/admin/lookbook/inspect/button/warning

#### Screenshots (if appropriate)
<img width="1435" height="619" alt="CleanShot 2569-07-14 at 15 46 34" src="https://github.com/user-attachments/assets/a4888925-57a9-48bf-8978-2db5ea504939" />

